### PR TITLE
allow newer versions of esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "@types/eslint": "^8.37.0",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^8.0.1",
-    "esbuild": "^0.17.14",
+    "esbuild": ">=0.17.14",
     "eslint": "^8.37.0",
     "eslint-config-sweet": "^11.0.2",
     "husky": "^8.0.3"
   },
   "peerDependencies": {
-    "esbuild": "^0.17.14",
+    "esbuild": ">=0.17.14",
     "eslint": "^8.37.0"
   },
   "scripts": {


### PR DESCRIPTION
I'm trying to use this package with esbuild@0.19.5 but the peer dependency can't be resolved because in [npm semver](https://github.com/npm/node-semver#caret-ranges-123-025-004) the caret resolves to the first non-zero place.  So ^0.17.14 is equivalent to `>=0.17.14 <0.18.0`

This change swaps the caret for a >= comparison so that 0.18, 0.19 and other future versions will match.