### PR TITLE
Fix lint duplicates in esbuild watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,14 @@ export default ({
   ...eslintOptions
 }: Options = {}): Plugin => ({
   name: "eslint",
-  setup: ({ onLoad, onEnd }) => {
+  setup: ({ onStart, onLoad, onEnd }) => {
     const eslint = new ESLint(eslintOptions);
     const filesToLint: OnLoadArgs["path"][] = [];
+
+    onStart(() => {
+      // Clear list of files from previous run in watch mode
+      filesToLint.splice(0);
+    });
 
     onLoad({ filter }, ({ path }) => {
       if (!path.includes("node_modules")) {


### PR DESCRIPTION
When esbuild is running in [watch mode](https://esbuild.github.io/api/#watch) the list of files to lint isn't cleared between runs and grows indefinitely with duplicates. This PR fixes that.